### PR TITLE
Fix a typo (?)

### DIFF
--- a/floating-point.Rmd
+++ b/floating-point.Rmd
@@ -179,7 +179,7 @@ We can verify that it works by coding it up.
 log_p = 0
 for (n in 1:N)
   log_p += bernoulli(y[n] | 0.5)
-print 'prob = ' p
+print 'prob = ' log_p
 ```
 
 We have replaced the variable `p` representing the probability with


### PR DESCRIPTION
It seems to me that it is a typo because when I look at the R code I see that the `printf` prints the `log_p` variable.